### PR TITLE
Testing/abstract serial port class for unit test

### DIFF
--- a/hans_cute_controllers/nodes/src/controller_manager.cpp
+++ b/hans_cute_controllers/nodes/src/controller_manager.cpp
@@ -33,7 +33,7 @@ void HansCuteControllerManager::initialise()
 
   std::string port_namespace = port.substr(5); // Remove /dev/ from port name
   // Shared pointer for hardware driver
-  servo_driver_ptr_ = std::make_shared<HansCuteRobot::ServoDriver>(port, baud_rate);
+  servo_driver_ptr_ = std::make_shared<HansCuteRobot::ServoDriver>();
   servo_driver_ptr_->open();
 
   status_manager_ptr_ = std::make_shared<HansCuteStatusManager>();

--- a/hans_cute_driver/CMakeLists.txt
+++ b/hans_cute_driver/CMakeLists.txt
@@ -210,13 +210,16 @@ target_link_libraries(${PROJECT_NAME}_node
 # ############
 
 # # Add gtest based cpp test target and link libraries
-# set(${PROJECT_NAME}_TESTS
-# )
-# catkin_add_gtest(${PROJECT_NAME}-test ${${PROJECT_NAME}_TESTS})
+set(${PROJECT_NAME}_TESTS
+  test/test_hans_cute_driver.cpp
+)
+catkin_add_gtest(${PROJECT_NAME}-test ${${PROJECT_NAME}_TESTS})
 
-# if(TARGET ${PROJECT_NAME}-test)
-# target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
+target_link_libraries(${PROJECT_NAME}-test 
+  ${PROJECT_NAME}
+  custom_serial_port
+)
+
 
 # # Add folders to be run by python nosetests
 # catkin_add_nosetests(test)

--- a/hans_cute_driver/CMakeLists.txt
+++ b/hans_cute_driver/CMakeLists.txt
@@ -10,6 +10,8 @@ add_compile_options(-std=c++17)
 find_package(catkin REQUIRED COMPONENTS
 )
 
+add_subdirectory(custom_serial_port)
+
 # # System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 
@@ -100,8 +102,8 @@ find_package(catkin REQUIRED COMPONENTS
 # # DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
 
-  INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME}
+  INCLUDE_DIRS include custom_serial_port/include
+  LIBRARIES ${PROJECT_NAME} custom_serial_port
   CATKIN_DEPENDS roscpp
 
   # DEPENDS system_lib
@@ -110,8 +112,8 @@ catkin_package(
 # ##########
 # # Build ##
 # ##########
+
 set(${PROJECT_NAME}_SOURCES
-  src/custom_serial_port.cpp
   src/serial_command.cpp
   src/hans_cute_serial.cpp
   src/hans_cute_driver.cpp
@@ -123,6 +125,7 @@ set(${PROJECT_NAME}_SOURCES
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
+  custom_serial_port/include
 )
 
 # # Declare a C++ library
@@ -136,6 +139,7 @@ add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EX
 # # Specify libraries to link a library or executable target against
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
+  custom_serial_port
 )
 
 # # Declare a C++ executable
@@ -156,6 +160,7 @@ add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catk
 # # Specify libraries to link a library or executable target against
 target_link_libraries(${PROJECT_NAME}_node
   ${catkin_LIBRARIES}
+  custom_serial_port
 )
 
 # ############
@@ -210,7 +215,7 @@ target_link_libraries(${PROJECT_NAME}_node
 # catkin_add_gtest(${PROJECT_NAME}-test ${${PROJECT_NAME}_TESTS})
 
 # if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
 # endif()
 
 # # Add folders to be run by python nosetests

--- a/hans_cute_driver/custom_serial_port/CMakeLists.txt
+++ b/hans_cute_driver/custom_serial_port/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Set the project name
+cmake_minimum_required(VERSION 3.0.2)
+project(custom_serial_port)
+
+# # Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++17)
+
+set(${PROJECT_NAME}_SOURCES
+  src/custom_serial_port.cpp
+)
+
+# Add a library with the above sources
+add_library(${PROJECT_NAME} ${${PROJECT_NAME}_SOURCES})
+
+target_include_directories(${PROJECT_NAME}
+    PUBLIC ${PROJECT_SOURCE_DIR}/include
+)

--- a/hans_cute_driver/custom_serial_port/CMakeLists.txt
+++ b/hans_cute_driver/custom_serial_port/CMakeLists.txt
@@ -7,6 +7,7 @@ add_compile_options(-std=c++17)
 
 set(${PROJECT_NAME}_SOURCES
   src/custom_serial_port.cpp
+  src/dummy_serial_port.cpp
 )
 
 # Add a library with the above sources

--- a/hans_cute_driver/custom_serial_port/include/custom_serial_port/custom_serial_port.h
+++ b/hans_cute_driver/custom_serial_port/include/custom_serial_port/custom_serial_port.h
@@ -37,6 +37,8 @@
 #include <asm/ioctls.h>
 #include <asm/termbits.h>
 
+#include "custom_serial_port/serial_port_interface.h"
+
 enum class NumDataBits
 {
   FIVE,
@@ -58,7 +60,7 @@ enum class NumStopBits
   TWO,
 };
 
-class SerialPort
+class SerialPort : public SerialPortInterfaces
 {
 public:
   SerialPort(const std::string& port, const speed_t& baud_rate, int32_t timeout);

--- a/hans_cute_driver/custom_serial_port/include/custom_serial_port/custom_serial_port.h
+++ b/hans_cute_driver/custom_serial_port/include/custom_serial_port/custom_serial_port.h
@@ -60,7 +60,7 @@ enum class NumStopBits
   TWO,
 };
 
-class SerialPort : public SerialPortInterfaces
+class SerialPort : public SerialPortInterface
 {
 public:
   SerialPort(const std::string& port, const speed_t& baud_rate, int32_t timeout);

--- a/hans_cute_driver/custom_serial_port/include/custom_serial_port/custom_serial_port.h
+++ b/hans_cute_driver/custom_serial_port/include/custom_serial_port/custom_serial_port.h
@@ -90,6 +90,9 @@ public:
 private:
   void configure();
 
+  void setReadDataStream(const std::vector<uint8_t> &data) {};
+  void getWriteDataStream(std::vector<uint8_t> &data) {};
+
   std::string port_;
   speed_t baud_rate_;
 

--- a/hans_cute_driver/custom_serial_port/include/custom_serial_port/dummy_serial_port.h
+++ b/hans_cute_driver/custom_serial_port/include/custom_serial_port/dummy_serial_port.h
@@ -21,9 +21,14 @@ public:
   unsigned int read(std::vector<uint8_t> &data);
   int available();
 
+  void setReadDataStream(const std::vector<uint8_t> &data);
+  void getWriteDataStream(std::vector<uint8_t> &data);
+
 private:
   std::string port_;
   unsigned int baud_rate_;
+  std::vector<uint8_t> write_data_stream_;
+  std::vector<uint8_t> read_data_stream_;
 };
 
 #endif

--- a/hans_cute_driver/custom_serial_port/include/custom_serial_port/dummy_serial_port.h
+++ b/hans_cute_driver/custom_serial_port/include/custom_serial_port/dummy_serial_port.h
@@ -1,0 +1,24 @@
+#ifndef _DUMMY_SERIAL_PORT_H_
+#define _DUMMY_SERIAL_PORT_H_
+
+#include <string>
+
+#include "serial_port_interface.h"
+
+class DummySerialPort : public SerialPortInterfaces
+{
+public:
+  DummySerialPort(const std::string& port, const unsigned int& baud_rate);
+  ~DummySerialPort();
+
+  void openPort();
+  void closePort();
+
+  void write(const std::vector<uint8_t> &data);
+  void wait();
+
+  unsigned int read(std::vector<uint8_t> &data);
+  int available();
+};
+
+#endif

--- a/hans_cute_driver/custom_serial_port/include/custom_serial_port/dummy_serial_port.h
+++ b/hans_cute_driver/custom_serial_port/include/custom_serial_port/dummy_serial_port.h
@@ -2,10 +2,11 @@
 #define _DUMMY_SERIAL_PORT_H_
 
 #include <string>
+#include <iostream>
 
 #include "serial_port_interface.h"
 
-class DummySerialPort : public SerialPortInterfaces
+class DummySerialPort : public SerialPortInterface
 {
 public:
   DummySerialPort(const std::string& port, const unsigned int& baud_rate);
@@ -19,6 +20,10 @@ public:
 
   unsigned int read(std::vector<uint8_t> &data);
   int available();
+
+private:
+  std::string port_;
+  unsigned int baud_rate_;
 };
 
 #endif

--- a/hans_cute_driver/custom_serial_port/include/custom_serial_port/serial_port_interface.h
+++ b/hans_cute_driver/custom_serial_port/include/custom_serial_port/serial_port_interface.h
@@ -1,0 +1,22 @@
+#ifndef _SERIAL_PORT_INTERFACE_H_
+#define _SERIAL_PORT_INTERFACE_H_
+
+#include <vector>
+
+class SerialPortInterfaces
+{
+  public:
+    SerialPortInterfaces(){};
+    virtual ~SerialPortInterfaces(){};
+
+    virtual void openPort() = 0;
+    virtual void closePort() = 0;
+
+    virtual void write(const std::vector<uint8_t>& data) = 0;
+    virtual void wait() = 0;
+
+    virtual unsigned int read(std::vector<uint8_t>& data) = 0;
+
+};
+
+#endif

--- a/hans_cute_driver/custom_serial_port/include/custom_serial_port/serial_port_interface.h
+++ b/hans_cute_driver/custom_serial_port/include/custom_serial_port/serial_port_interface.h
@@ -3,11 +3,11 @@
 
 #include <vector>
 
-class SerialPortInterfaces
+class SerialPortInterface
 {
   public:
-    SerialPortInterfaces(){};
-    virtual ~SerialPortInterfaces(){};
+    SerialPortInterface(){};
+    virtual ~SerialPortInterface(){};
 
     virtual void openPort() = 0;
     virtual void closePort() = 0;
@@ -16,6 +16,8 @@ class SerialPortInterfaces
     virtual void wait() = 0;
 
     virtual unsigned int read(std::vector<uint8_t>& data) = 0;
+
+    virtual int available() = 0;
 
 };
 

--- a/hans_cute_driver/custom_serial_port/include/custom_serial_port/serial_port_interface.h
+++ b/hans_cute_driver/custom_serial_port/include/custom_serial_port/serial_port_interface.h
@@ -5,20 +5,22 @@
 
 class SerialPortInterface
 {
-  public:
-    SerialPortInterface(){};
-    virtual ~SerialPortInterface(){};
+public:
+  SerialPortInterface(){};
+  virtual ~SerialPortInterface(){};
 
-    virtual void openPort() = 0;
-    virtual void closePort() = 0;
+  virtual void openPort() = 0;
+  virtual void closePort() = 0;
 
-    virtual void write(const std::vector<uint8_t>& data) = 0;
-    virtual void wait() = 0;
+  virtual void write(const std::vector<uint8_t> &data) = 0;
+  virtual void wait() = 0;
 
-    virtual unsigned int read(std::vector<uint8_t>& data) = 0;
+  virtual unsigned int read(std::vector<uint8_t> &data) = 0;
 
-    virtual int available() = 0;
-
+  virtual int available() = 0;
+  
+  virtual void setReadDataStream(const std::vector<uint8_t> &data) = 0;
+  virtual void getWriteDataStream(std::vector<uint8_t> &data) = 0 ;
 };
 
 #endif

--- a/hans_cute_driver/custom_serial_port/src/custom_serial_port.cpp
+++ b/hans_cute_driver/custom_serial_port/src/custom_serial_port.cpp
@@ -1,4 +1,5 @@
-#include "hans_cute_driver/custom_serial_port.h"
+#include "custom_serial_port/custom_serial_port.h"
+
 SerialPort::SerialPort(const std::string& port, const speed_t& baud_rate, int32_t timeout)
   : port_(port)
   , baud_rate_(baud_rate)

--- a/hans_cute_driver/custom_serial_port/src/dummy_serial_port.cpp
+++ b/hans_cute_driver/custom_serial_port/src/dummy_serial_port.cpp
@@ -1,0 +1,9 @@
+#include "custom_serial_port/dummy_serial_port.h"
+
+DummySerialPort::DummySerialPort(const std::string &port, const unsigned int &baud_rate)
+{
+}
+
+DummySerialPort ~DummySerialPort()
+{
+}

--- a/hans_cute_driver/custom_serial_port/src/dummy_serial_port.cpp
+++ b/hans_cute_driver/custom_serial_port/src/dummy_serial_port.cpp
@@ -18,10 +18,7 @@ void DummySerialPort::closePort()
 
 void DummySerialPort::write(const std::vector<uint8_t> &data)
 {
-  for (const uint8_t data_point : data)
-  {
-    std::cout << (int)data_point << std::endl;
-  }
+  write_data_stream_ = data;
 }
 
 void DummySerialPort::wait()
@@ -30,9 +27,21 @@ void DummySerialPort::wait()
 
 unsigned int DummySerialPort::read(std::vector<uint8_t> &data)
 {
+  data = read_data_stream_;
+  return read_data_stream_.size();
 }
 
 int DummySerialPort::available()
 {
   return 1;
+}
+
+void DummySerialPort::getWriteDataStream(std::vector<uint8_t> &data)
+{
+  data = write_data_stream_;
+}
+
+void DummySerialPort::setReadDataStream(const std::vector<uint8_t> &data)
+{
+  read_data_stream_ = data;
 }

--- a/hans_cute_driver/custom_serial_port/src/dummy_serial_port.cpp
+++ b/hans_cute_driver/custom_serial_port/src/dummy_serial_port.cpp
@@ -4,6 +4,35 @@ DummySerialPort::DummySerialPort(const std::string &port, const unsigned int &ba
 {
 }
 
-DummySerialPort ~DummySerialPort()
+DummySerialPort::~DummySerialPort()
 {
+}
+
+void DummySerialPort::openPort()
+{
+}
+
+void DummySerialPort::closePort()
+{
+}
+
+void DummySerialPort::write(const std::vector<uint8_t> &data)
+{
+  for (const uint8_t data_point : data)
+  {
+    std::cout << (int)data_point << std::endl;
+  }
+}
+
+void DummySerialPort::wait()
+{
+}
+
+unsigned int DummySerialPort::read(std::vector<uint8_t> &data)
+{
+}
+
+int DummySerialPort::available()
+{
+  return 1;
 }

--- a/hans_cute_driver/include/hans_cute_driver/hans_cute_driver.h
+++ b/hans_cute_driver/include/hans_cute_driver/hans_cute_driver.h
@@ -12,7 +12,7 @@ namespace HansCuteRobot
   public:
     static const SamplePacket DXL_PACKET;
 
-    ServoDriver(const std::string port, const long baudrate);
+    ServoDriver();
     ~ServoDriver();
 
     //====================================================================//

--- a/hans_cute_driver/include/hans_cute_driver/hans_cute_serial.h
+++ b/hans_cute_driver/include/hans_cute_driver/hans_cute_serial.h
@@ -6,25 +6,22 @@
 
 namespace HansCuteRobot
 {
-class ServoSerialComms : public SerialCommand
-{
-public:
-  ServoSerialComms(const std::string port, const long baudrate);
-  ~ServoSerialComms();
+  class ServoSerialComms : public SerialCommand
+  {
+  public:
+    ServoSerialComms(const std::string port, const long baudrate);
+    ~ServoSerialComms();
 
-  bool readResponse(std::vector<uint8_t>& response);
-  bool writeCommand(const std::vector<uint8_t>& command);
+    bool readResponse(std::vector<uint8_t> &response);
+    bool writeCommand(const std::vector<uint8_t> &command);
 
-  bool read(const uint8_t& id, const uint8_t& address, const uint8_t& size, std::vector<uint8_t>& returned_data,
-            unsigned long& timestamp);
-  bool write(const uint8_t& id, const uint8_t& address, const std::vector<uint8_t>& data,
-             std::vector<uint8_t>& returned_data, unsigned long& timestamp);
-  bool syncWrite(const uint8_t& address, const std::vector<std::vector<uint8_t> >& data);
+    bool read(const uint8_t &id, const uint8_t &address, const uint8_t &size, unsigned long &timestamp);
+    bool write(const uint8_t &id, const uint8_t &address, const std::vector<uint8_t> &data, unsigned long &timestamp);
+    bool syncWrite(const uint8_t &address, const std::vector<std::vector<uint8_t>> &data);
+    bool ping(const uint8_t &id);
 
-  bool ping(const uint8_t& id, std::vector<uint8_t>& returned_data);
-
-  uint8_t calcCheckSum(std::vector<uint8_t>& data) const;
-};
-};  // namespace HansCuteRobot
+    uint8_t calcCheckSum(std::vector<uint8_t> &data) const;
+  };
+}; // namespace HansCuteRobot
 
 #endif

--- a/hans_cute_driver/include/hans_cute_driver/hans_cute_serial.h
+++ b/hans_cute_driver/include/hans_cute_driver/hans_cute_serial.h
@@ -15,10 +15,13 @@ namespace HansCuteRobot
     bool readResponse(std::vector<uint8_t> &response);
     bool writeCommand(const std::vector<uint8_t> &command);
 
-    bool read(const uint8_t &id, const uint8_t &address, const uint8_t &size, unsigned long &timestamp);
-    bool write(const uint8_t &id, const uint8_t &address, const std::vector<uint8_t> &data, unsigned long &timestamp);
+    bool read(const uint8_t &id, const uint8_t &address, const uint8_t &size, std::vector<uint8_t> &returned_data,
+              unsigned long &timestamp);
+    bool write(const uint8_t &id, const uint8_t &address, const std::vector<uint8_t> &data,
+               std::vector<uint8_t> &returned_data, unsigned long &timestamp);
     bool syncWrite(const uint8_t &address, const std::vector<std::vector<uint8_t>> &data);
-    bool ping(const uint8_t &id);
+
+    bool ping(const uint8_t &id, std::vector<uint8_t> &returned_data);
 
     uint8_t calcCheckSum(std::vector<uint8_t> &data) const;
   };

--- a/hans_cute_driver/include/hans_cute_driver/hans_cute_serial.h
+++ b/hans_cute_driver/include/hans_cute_driver/hans_cute_serial.h
@@ -9,7 +9,7 @@ namespace HansCuteRobot
   class ServoSerialComms : public SerialCommand
   {
   public:
-    ServoSerialComms(const std::string port, const long baudrate);
+    ServoSerialComms();
     ~ServoSerialComms();
 
     bool readResponse(std::vector<uint8_t> &response);

--- a/hans_cute_driver/include/hans_cute_driver/serial_command.h
+++ b/hans_cute_driver/include/hans_cute_driver/serial_command.h
@@ -25,6 +25,13 @@ struct SamplePacket
   unsigned int data;            // Start position of data byte
 };
 
+enum class SerialError
+{
+  NO_RESPONSE = 0,
+  WRONG_HEADER = 1,
+  WRONG_CHECKSUM = 2,
+};
+
 class SerialCommand : public SerialCommandInterface
 {
 public:

--- a/hans_cute_driver/include/hans_cute_driver/serial_command.h
+++ b/hans_cute_driver/include/hans_cute_driver/serial_command.h
@@ -28,11 +28,7 @@ struct SamplePacket
 class SerialCommand : public SerialCommandInterface
 {
 public:
-  SerialCommand(const std::string port, const long baudrate);
-  /**
-   * @brief Default constructor
-   *
-   */
+  SerialCommand(const unsigned int &timeout, const unsigned int &num_tries);
   SerialCommand();
   virtual ~SerialCommand();
 
@@ -49,8 +45,6 @@ public:
 
 protected:
   std::shared_ptr<SerialPortInterface> serial_port_;
-  std::string port_;
-  unsigned int baudrate_;
   unsigned int timeout_;
   unsigned int num_tries_;
   SamplePacket sample_packet_;

--- a/hans_cute_driver/include/hans_cute_driver/serial_command.h
+++ b/hans_cute_driver/include/hans_cute_driver/serial_command.h
@@ -13,16 +13,16 @@
 #include <csignal>
 
 // New native serial library
-#include "custom_serial_port/custom_serial_port.h"
+#include "custom_serial_port/serial_port_interface.h"
 
 #include "serial_command_interface.h"
 
 struct SamplePacket
 {
-  std::vector<uint8_t> headers;  // Headers in HEX
-  unsigned int id;               // Position of the id byte
-  unsigned int length;           // Position of length byte
-  unsigned int data;             // Start position of data byte
+  std::vector<uint8_t> headers; // Headers in HEX
+  unsigned int id;              // Position of the id byte
+  unsigned int length;          // Position of length byte
+  unsigned int data;            // Start position of data byte
 };
 
 class SerialCommand : public SerialCommandInterface
@@ -39,22 +39,22 @@ public:
   virtual void open() const;
   virtual void close() const;
 
+  void setSerialPort(const std::shared_ptr<SerialPortInterface> &serial_port);
   void setSamplePacket(const SamplePacket sample_packet);
 
-  virtual bool readResponse(std::vector<uint8_t>& response) override;
-  virtual bool writeCommand(const std::vector<uint8_t>& command) override;
+  virtual bool readResponse(std::vector<uint8_t> &response) override;
+  virtual bool writeCommand(const std::vector<uint8_t> &command) override;
 
-  virtual uint8_t calcCheckSum(std::vector<uint8_t>& data) const = 0;
+  virtual uint8_t calcCheckSum(std::vector<uint8_t> &data) const = 0;
 
 protected:
-  
-  std::shared_ptr<SerialPort> _serial_port;
-  std::string _port;
-  unsigned int _baudrate;
-  unsigned int _timeout;
-  unsigned int _num_tries;
-  SamplePacket _sample_packet;
-  std::mutex _comms_mtx;
+  std::shared_ptr<SerialPortInterface> serial_port_;
+  std::string port_;
+  unsigned int baudrate_;
+  unsigned int timeout_;
+  unsigned int num_tries_;
+  SamplePacket sample_packet_;
+  std::mutex comms_mtx_;
 };
 
 #endif

--- a/hans_cute_driver/include/hans_cute_driver/serial_command.h
+++ b/hans_cute_driver/include/hans_cute_driver/serial_command.h
@@ -13,7 +13,7 @@
 #include <csignal>
 
 // New native serial library
-#include "custom_serial_port.h"
+#include "custom_serial_port/custom_serial_port.h"
 
 #include "serial_command_interface.h"
 

--- a/hans_cute_driver/include/hans_cute_driver/serial_command_interface.h
+++ b/hans_cute_driver/include/hans_cute_driver/serial_command_interface.h
@@ -2,6 +2,7 @@
 #define _SERIAL_COMMAND_INTERFACE_H_
 
 #include <vector>
+#include "custom_serial_port/serial_port_interface.h"
 
 class SerialCommandInterface
 {
@@ -9,13 +10,15 @@ public:
   SerialCommandInterface(){};
   virtual ~SerialCommandInterface(){};
 
+  virtual void setSerialPort(const std::shared_ptr<SerialPortInterface> &serial_port) = 0;
+
   virtual void open() const = 0;
   virtual void close() const = 0;
 
-  virtual bool readResponse(std::vector<uint8_t>& response) = 0;
-  virtual bool writeCommand(const std::vector<uint8_t>& command) = 0;
+  virtual bool readResponse(std::vector<uint8_t> &response) = 0;
+  virtual bool writeCommand(const std::vector<uint8_t> &command) = 0;
 
-  virtual uint8_t calcCheckSum(std::vector<uint8_t>& data) const = 0;
+  virtual uint8_t calcCheckSum(std::vector<uint8_t> &data) const = 0;
 };
 
 #endif

--- a/hans_cute_driver/node/hans_cute_driver_cli.cpp
+++ b/hans_cute_driver/node/hans_cute_driver_cli.cpp
@@ -1,0 +1,5 @@
+
+int main(int argc, char **argv)
+{
+  return 0;
+}

--- a/hans_cute_driver/package.xml
+++ b/hans_cute_driver/package.xml
@@ -51,10 +51,13 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>serial</build_depend>
+  <build_depend>custom_serial_port</build_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>serial</build_export_depend>
+  <build_export_depend>custom_serial_port</build_export_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>serial</exec_depend>
+  <exec_depend>custom_serial_port</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/hans_cute_driver/src/hans_cute_driver.cpp
+++ b/hans_cute_driver/src/hans_cute_driver.cpp
@@ -11,7 +11,7 @@ HansCuteRobot::ServoDriver::ServoDriver()
 
 HansCuteRobot::ServoDriver::~ServoDriver()
 {
-  std::cout << "ServoDriver destructor" << std::endl;
+  // std::cout << "ServoDriver destructor" << std::endl;
 }
 
 //====================================================================//
@@ -38,8 +38,8 @@ bool HansCuteRobot::ServoDriver::setAngleLimits(const uint8_t &servo_id, const u
   std::vector<uint8_t> raw_limit = HansCuteRobot::AngleLimits::getRawData(min_limit, max_limit);
   std::vector<uint8_t> returned_data;
   unsigned long timestamp;
-  write(servo_id, (uint8_t)ControlTableConstant::CW_ANGLE_LIMIT_L, raw_limit, timestamp);
-  return readResponse(returned_data);
+  write(servo_id, (uint8_t)ControlTableConstant::CW_ANGLE_LIMIT_L, raw_limit, returned_data, timestamp);
+  return true;
 }
 
 bool HansCuteRobot::ServoDriver::setVoltageLimits(const uint8_t &servo_id, const VoltageLimits &voltage_limits)
@@ -52,8 +52,12 @@ bool HansCuteRobot::ServoDriver::setMaxTorque(const uint8_t &servo_id, const uns
   std::vector<uint8_t> raw_limit = HansCuteRobot::TorqueLimit::getRawData(max_torque);
   std::vector<uint8_t> returned_data;
   unsigned long timestamp;
-  write(servo_id, (uint8_t)ControlTableConstant::MAX_TORQUE_L, raw_limit, timestamp);
-  return readResponse(returned_data);
+  write(servo_id, (uint8_t)ControlTableConstant::MAX_TORQUE_L, raw_limit, returned_data, timestamp);
+  for (uint8_t data : returned_data)
+  {
+    std::cout << (int)data << std::endl;
+  }
+  return true;
 }
 
 //===============================================================//
@@ -64,8 +68,8 @@ bool HansCuteRobot::ServoDriver::setTorqueEnable(const uint8_t &servo_id, const 
   std::vector<uint8_t> data({(uint8_t)enabled});
   std::vector<uint8_t> returned_data;
   unsigned long timestamp;
-  write(servo_id, (uint8_t)ControlTableConstant::TORQUE_ENABLE, data, timestamp);
-  return readResponse(returned_data);
+  write(servo_id, (uint8_t)ControlTableConstant::TORQUE_ENABLE, data, returned_data, timestamp);
+  return true;
 }
 bool HansCuteRobot::ServoDriver::setComplianceMargin()
 {
@@ -93,24 +97,24 @@ bool HansCuteRobot::ServoDriver::setAcceleration(const uint8_t &servo_id, const 
   std::vector<uint8_t> raw_data = HansCuteRobot::ServoAcceleration::getRawData(acceleration);
   std::vector<uint8_t> returned_data;
   unsigned long timestamp;
-  write(servo_id, (uint8_t)ControlTableConstant::GOAL_ACCELERATION, raw_data, timestamp);
-  return readResponse(returned_data);
+  write(servo_id, (uint8_t)ControlTableConstant::GOAL_ACCELERATION, raw_data, returned_data, timestamp);
+  return true;
 }
 bool HansCuteRobot::ServoDriver::setPosition(const uint8_t &servo_id, const unsigned int &position)
 {
   std::vector<uint8_t> raw_postion = HansCuteRobot::ServoPosition::getRawData(position);
   std::vector<uint8_t> returned_data;
   unsigned long timestamp;
-  write(servo_id, (uint8_t)ControlTableConstant::GOAL_POSITION_L, raw_postion, timestamp);
-  return readResponse(returned_data);
+  write(servo_id, (uint8_t)ControlTableConstant::GOAL_POSITION_L, raw_postion, returned_data, timestamp);
+  return true;
 }
 bool HansCuteRobot::ServoDriver::setSpeed(const uint8_t &servo_id, const unsigned int &speed)
 {
   std::vector<uint8_t> raw_speed = HansCuteRobot::ServoSpeed::getRawData(speed);
   std::vector<uint8_t> returned_data;
   unsigned long timestamp;
-  write(servo_id, (uint8_t)ControlTableConstant::GOAL_SPEED_L, raw_speed, timestamp);
-  return readResponse(returned_data);
+  write(servo_id, (uint8_t)ControlTableConstant::GOAL_SPEED_L, raw_speed, returned_data, timestamp);
+  return true;
 }
 
 bool HansCuteRobot::ServoDriver::setTorqueLimit(const uint8_t &servo_id, const unsigned int &torque_limit)
@@ -118,8 +122,8 @@ bool HansCuteRobot::ServoDriver::setTorqueLimit(const uint8_t &servo_id, const u
   std::vector<uint8_t> raw_torque = HansCuteRobot::TorqueLimit::getRawData(torque_limit);
   std::vector<uint8_t> returned_data;
   unsigned long timestamp;
-  write(servo_id, (uint8_t)ControlTableConstant::TORQUE_LIMIT_L, raw_torque, timestamp);
-  return readResponse(returned_data);
+  write(servo_id, (uint8_t)ControlTableConstant::TORQUE_LIMIT_L, raw_torque, returned_data, timestamp);
+  return true;
 }
 bool HansCuteRobot::ServoDriver::setGoalTorque()
 {
@@ -216,8 +220,7 @@ bool HansCuteRobot::ServoDriver::getModelNumber(const int &servo_id, unsigned in
 {
   std::vector<uint8_t> response;
   unsigned long timestamp = 0;
-  read((uint8_t)servo_id, (uint8_t)ControlTableConstant::MODEL_NUMBER_L, 2, timestamp);
-  if (!readResponse(response))
+  if (!read((uint8_t)servo_id, (uint8_t)ControlTableConstant::MODEL_NUMBER_L, 2, response, timestamp))
   {
     return false;
   }
@@ -237,8 +240,7 @@ bool HansCuteRobot::ServoDriver::getAngleLimits(const int &servo_id, HansCuteRob
 {
   std::vector<uint8_t> response;
   unsigned long timestamp = 0;
-  read((uint8_t)servo_id, (uint8_t)ControlTableConstant::CW_ANGLE_LIMIT_L, 4, timestamp);
-  if (!readResponse(response))
+  if (!read((uint8_t)servo_id, (uint8_t)ControlTableConstant::CW_ANGLE_LIMIT_L, 4, response, timestamp))
   {
     return false;
   }
@@ -250,8 +252,7 @@ bool HansCuteRobot::ServoDriver::getTorqueEnabled(const int &servo_id, bool &ena
 {
   std::vector<uint8_t> response;
   unsigned long timestamp = 0;
-  read((uint8_t)servo_id, (uint8_t)ControlTableConstant::TORQUE_ENABLE, 1, timestamp);
-  if (!readResponse(response))
+  if (!read((uint8_t)servo_id, (uint8_t)ControlTableConstant::TORQUE_ENABLE, 1, response, timestamp))
   {
     return false;
   }
@@ -262,8 +263,7 @@ bool HansCuteRobot::ServoDriver::getMaxTorque(const int &servo_id, unsigned int 
 {
   std::vector<uint8_t> response;
   unsigned long timestamp = 0;
-  read((uint8_t)servo_id, (uint8_t)ControlTableConstant::MAX_TORQUE_L, 2, timestamp);
-  if (!readResponse(response))
+  if (!read((uint8_t)servo_id, (uint8_t)ControlTableConstant::MAX_TORQUE_L, 2, response, timestamp))
   {
     return false;
   }
@@ -279,8 +279,7 @@ bool HansCuteRobot::ServoDriver::getPosition(const int &servo_id, unsigned int &
 {
   std::vector<uint8_t> response;
   unsigned long timestamp = 0;
-  read((uint8_t)servo_id, (uint8_t)ControlTableConstant::PRESENT_POSITION_L, 2, timestamp);
-  if (!readResponse(response))
+  if (!read((uint8_t)servo_id, (uint8_t)ControlTableConstant::PRESENT_POSITION_L, 2, response, timestamp))
   {
     return false;
   }
@@ -291,8 +290,7 @@ bool HansCuteRobot::ServoDriver::getSpeed(const int &servo_id, unsigned int &spe
 {
   std::vector<uint8_t> response;
   unsigned long timestamp = 0;
-  read((uint8_t)servo_id, (uint8_t)ControlTableConstant::GOAL_SPEED_L, 2, timestamp);
-  if (!readResponse(response))
+  if (!read((uint8_t)servo_id, (uint8_t)ControlTableConstant::GOAL_SPEED_L, 2, response, timestamp))
   {
     return false;
   }
@@ -313,8 +311,7 @@ bool HansCuteRobot::ServoDriver::getLock(const int &servo_id, bool &lock)
 {
   std::vector<uint8_t> response;
   unsigned long timestamp = 0;
-  read((uint8_t)servo_id, (uint8_t)ControlTableConstant::LOCK, 1, timestamp);
-  if (!readResponse(response))
+  if (!read((uint8_t)servo_id, (uint8_t)ControlTableConstant::LOCK, 1, response, timestamp))
   {
     return false;
   }
@@ -326,11 +323,11 @@ bool HansCuteRobot::ServoDriver::getFeedback(const int &servo_id, ServoFeedback 
 {
   std::vector<uint8_t> response;
   unsigned long timestamp = 0;
-  read((uint8_t)servo_id, (uint8_t)ControlTableConstant::GOAL_POSITION_L, 17, timestamp);
-  if (!readResponse(response))
+  if (!read((uint8_t)servo_id, (uint8_t)ControlTableConstant::GOAL_POSITION_L, 17, response, timestamp))
   {
     return false;
   }
+
   feedback = ServoFeedback::getData((uint8_t)servo_id, response, timestamp);
   return true;
 }

--- a/hans_cute_driver/src/hans_cute_driver.cpp
+++ b/hans_cute_driver/src/hans_cute_driver.cpp
@@ -38,8 +38,8 @@ bool HansCuteRobot::ServoDriver::setAngleLimits(const uint8_t &servo_id, const u
   std::vector<uint8_t> raw_limit = HansCuteRobot::AngleLimits::getRawData(min_limit, max_limit);
   std::vector<uint8_t> returned_data;
   unsigned long timestamp;
-  write(servo_id, (uint8_t)ControlTableConstant::CW_ANGLE_LIMIT_L, raw_limit, returned_data, timestamp);
-  return true;
+  write(servo_id, (uint8_t)ControlTableConstant::CW_ANGLE_LIMIT_L, raw_limit, timestamp);
+  return readResponse(returned_data);
 }
 
 bool HansCuteRobot::ServoDriver::setVoltageLimits(const uint8_t &servo_id, const VoltageLimits &voltage_limits)
@@ -52,12 +52,8 @@ bool HansCuteRobot::ServoDriver::setMaxTorque(const uint8_t &servo_id, const uns
   std::vector<uint8_t> raw_limit = HansCuteRobot::TorqueLimit::getRawData(max_torque);
   std::vector<uint8_t> returned_data;
   unsigned long timestamp;
-  write(servo_id, (uint8_t)ControlTableConstant::MAX_TORQUE_L, raw_limit, returned_data, timestamp);
-  for (uint8_t data : returned_data)
-  {
-    std::cout << (int)data << std::endl;
-  }
-  return true;
+  write(servo_id, (uint8_t)ControlTableConstant::MAX_TORQUE_L, raw_limit, timestamp);
+  return readResponse(returned_data);
 }
 
 //===============================================================//
@@ -68,8 +64,8 @@ bool HansCuteRobot::ServoDriver::setTorqueEnable(const uint8_t &servo_id, const 
   std::vector<uint8_t> data({(uint8_t)enabled});
   std::vector<uint8_t> returned_data;
   unsigned long timestamp;
-  write(servo_id, (uint8_t)ControlTableConstant::TORQUE_ENABLE, data, returned_data, timestamp);
-  return true;
+  write(servo_id, (uint8_t)ControlTableConstant::TORQUE_ENABLE, data, timestamp);
+  return readResponse(returned_data);
 }
 bool HansCuteRobot::ServoDriver::setComplianceMargin()
 {
@@ -97,24 +93,24 @@ bool HansCuteRobot::ServoDriver::setAcceleration(const uint8_t &servo_id, const 
   std::vector<uint8_t> raw_data = HansCuteRobot::ServoAcceleration::getRawData(acceleration);
   std::vector<uint8_t> returned_data;
   unsigned long timestamp;
-  write(servo_id, (uint8_t)ControlTableConstant::GOAL_ACCELERATION, raw_data, returned_data, timestamp);
-  return true;
+  write(servo_id, (uint8_t)ControlTableConstant::GOAL_ACCELERATION, raw_data, timestamp);
+  return readResponse(returned_data);
 }
 bool HansCuteRobot::ServoDriver::setPosition(const uint8_t &servo_id, const unsigned int &position)
 {
   std::vector<uint8_t> raw_postion = HansCuteRobot::ServoPosition::getRawData(position);
   std::vector<uint8_t> returned_data;
   unsigned long timestamp;
-  write(servo_id, (uint8_t)ControlTableConstant::GOAL_POSITION_L, raw_postion, returned_data, timestamp);
-  return true;
+  write(servo_id, (uint8_t)ControlTableConstant::GOAL_POSITION_L, raw_postion, timestamp);
+  return readResponse(returned_data);
 }
 bool HansCuteRobot::ServoDriver::setSpeed(const uint8_t &servo_id, const unsigned int &speed)
 {
   std::vector<uint8_t> raw_speed = HansCuteRobot::ServoSpeed::getRawData(speed);
   std::vector<uint8_t> returned_data;
   unsigned long timestamp;
-  write(servo_id, (uint8_t)ControlTableConstant::GOAL_SPEED_L, raw_speed, returned_data, timestamp);
-  return true;
+  write(servo_id, (uint8_t)ControlTableConstant::GOAL_SPEED_L, raw_speed, timestamp);
+  return readResponse(returned_data);
 }
 
 bool HansCuteRobot::ServoDriver::setTorqueLimit(const uint8_t &servo_id, const unsigned int &torque_limit)
@@ -122,8 +118,8 @@ bool HansCuteRobot::ServoDriver::setTorqueLimit(const uint8_t &servo_id, const u
   std::vector<uint8_t> raw_torque = HansCuteRobot::TorqueLimit::getRawData(torque_limit);
   std::vector<uint8_t> returned_data;
   unsigned long timestamp;
-  write(servo_id, (uint8_t)ControlTableConstant::TORQUE_LIMIT_L, raw_torque, returned_data, timestamp);
-  return true;
+  write(servo_id, (uint8_t)ControlTableConstant::TORQUE_LIMIT_L, raw_torque, timestamp);
+  return readResponse(returned_data);
 }
 bool HansCuteRobot::ServoDriver::setGoalTorque()
 {
@@ -220,7 +216,8 @@ bool HansCuteRobot::ServoDriver::getModelNumber(const int &servo_id, unsigned in
 {
   std::vector<uint8_t> response;
   unsigned long timestamp = 0;
-  if (!read((uint8_t)servo_id, (uint8_t)ControlTableConstant::MODEL_NUMBER_L, 2, response, timestamp))
+  read((uint8_t)servo_id, (uint8_t)ControlTableConstant::MODEL_NUMBER_L, 2, timestamp);
+  if (!readResponse(response))
   {
     return false;
   }
@@ -240,7 +237,8 @@ bool HansCuteRobot::ServoDriver::getAngleLimits(const int &servo_id, HansCuteRob
 {
   std::vector<uint8_t> response;
   unsigned long timestamp = 0;
-  if (!read((uint8_t)servo_id, (uint8_t)ControlTableConstant::CW_ANGLE_LIMIT_L, 4, response, timestamp))
+  read((uint8_t)servo_id, (uint8_t)ControlTableConstant::CW_ANGLE_LIMIT_L, 4, timestamp);
+  if (!readResponse(response))
   {
     return false;
   }
@@ -252,7 +250,8 @@ bool HansCuteRobot::ServoDriver::getTorqueEnabled(const int &servo_id, bool &ena
 {
   std::vector<uint8_t> response;
   unsigned long timestamp = 0;
-  if (!read((uint8_t)servo_id, (uint8_t)ControlTableConstant::TORQUE_ENABLE, 1, response, timestamp))
+  read((uint8_t)servo_id, (uint8_t)ControlTableConstant::TORQUE_ENABLE, 1, timestamp);
+  if (!readResponse(response))
   {
     return false;
   }
@@ -263,7 +262,8 @@ bool HansCuteRobot::ServoDriver::getMaxTorque(const int &servo_id, unsigned int 
 {
   std::vector<uint8_t> response;
   unsigned long timestamp = 0;
-  if (!read((uint8_t)servo_id, (uint8_t)ControlTableConstant::MAX_TORQUE_L, 2, response, timestamp))
+  read((uint8_t)servo_id, (uint8_t)ControlTableConstant::MAX_TORQUE_L, 2, timestamp);
+  if (!readResponse(response))
   {
     return false;
   }
@@ -279,7 +279,8 @@ bool HansCuteRobot::ServoDriver::getPosition(const int &servo_id, unsigned int &
 {
   std::vector<uint8_t> response;
   unsigned long timestamp = 0;
-  if (!read((uint8_t)servo_id, (uint8_t)ControlTableConstant::PRESENT_POSITION_L, 2, response, timestamp))
+  read((uint8_t)servo_id, (uint8_t)ControlTableConstant::PRESENT_POSITION_L, 2, timestamp);
+  if (!readResponse(response))
   {
     return false;
   }
@@ -290,7 +291,8 @@ bool HansCuteRobot::ServoDriver::getSpeed(const int &servo_id, unsigned int &spe
 {
   std::vector<uint8_t> response;
   unsigned long timestamp = 0;
-  if (!read((uint8_t)servo_id, (uint8_t)ControlTableConstant::GOAL_SPEED_L, 2, response, timestamp))
+  read((uint8_t)servo_id, (uint8_t)ControlTableConstant::GOAL_SPEED_L, 2, timestamp);
+  if (!readResponse(response))
   {
     return false;
   }
@@ -311,7 +313,8 @@ bool HansCuteRobot::ServoDriver::getLock(const int &servo_id, bool &lock)
 {
   std::vector<uint8_t> response;
   unsigned long timestamp = 0;
-  if (!read((uint8_t)servo_id, (uint8_t)ControlTableConstant::LOCK, 1, response, timestamp))
+  read((uint8_t)servo_id, (uint8_t)ControlTableConstant::LOCK, 1, timestamp);
+  if (!readResponse(response))
   {
     return false;
   }
@@ -323,11 +326,11 @@ bool HansCuteRobot::ServoDriver::getFeedback(const int &servo_id, ServoFeedback 
 {
   std::vector<uint8_t> response;
   unsigned long timestamp = 0;
-  if (!read((uint8_t)servo_id, (uint8_t)ControlTableConstant::GOAL_POSITION_L, 17, response, timestamp))
+  read((uint8_t)servo_id, (uint8_t)ControlTableConstant::GOAL_POSITION_L, 17, timestamp);
+  if (!readResponse(response))
   {
     return false;
   }
-
   feedback = ServoFeedback::getData((uint8_t)servo_id, response, timestamp);
   return true;
 }

--- a/hans_cute_driver/src/hans_cute_driver.cpp
+++ b/hans_cute_driver/src/hans_cute_driver.cpp
@@ -2,8 +2,8 @@
 
 const SamplePacket HansCuteRobot::ServoDriver::DXL_PACKET{std::vector<uint8_t>({0xFF, 0xFF}), 2, 3, 4};
 
-HansCuteRobot::ServoDriver::ServoDriver(const std::string port, const long baudrate)
-    : HansCuteRobot::ServoSerialComms(port, baudrate)
+HansCuteRobot::ServoDriver::ServoDriver()
+    : HansCuteRobot::ServoSerialComms()
 {
   // Update paket format at initialisation
   setSamplePacket(HansCuteRobot::ServoDriver::DXL_PACKET);

--- a/hans_cute_driver/src/hans_cute_serial.cpp
+++ b/hans_cute_driver/src/hans_cute_serial.cpp
@@ -1,6 +1,6 @@
 #include "hans_cute_driver/hans_cute_serial.h"
 
-HansCuteRobot::ServoSerialComms::ServoSerialComms(const std::string port, const long baudrate) : SerialCommand(port, baudrate)
+HansCuteRobot::ServoSerialComms::ServoSerialComms() : SerialCommand()
 {
 }
 

--- a/hans_cute_driver/src/main.cpp
+++ b/hans_cute_driver/src/main.cpp
@@ -9,7 +9,7 @@
 int main(int argc, char *argv[])
 {
   std::shared_ptr<SerialPortInterface> serial_port = std::make_shared<DummySerialPort>("/dev/ttyUSB0", 250000);
-  HansCuteRobot::ServoDriver hans_robot("/dev/ttyUSB0", 250000);
+  HansCuteRobot::ServoDriver hans_robot;
   hans_robot.setSerialPort(serial_port);
   hans_robot.open();
 

--- a/hans_cute_driver/src/main.cpp
+++ b/hans_cute_driver/src/main.cpp
@@ -3,10 +3,15 @@
 #include "hans_cute_driver/hans_cute_driver.h"
 #include "hans_cute_driver/hans_cute_datatype.h"
 
-int main(int argc, char* argv[])
+#include "custom_serial_port/dummy_serial_port.h"
+#include "custom_serial_port/serial_port_interface.h"
+
+int main(int argc, char *argv[])
 {
-  // HansCuteRobot::ServoDriver hans_robot("/dev/ttyUSB0", 250000);
-  // hans_robot.open();
+  std::shared_ptr<SerialPortInterface> serial_port = std::make_shared<DummySerialPort>("/dev/ttyUSB0", 250000);
+  HansCuteRobot::ServoDriver hans_robot("/dev/ttyUSB0", 250000);
+  hans_robot.setSerialPort(serial_port);
+  hans_robot.open();
 
   // std::vector<unsigned int> servo_ids;
   // std::vector<unsigned int> positions;
@@ -17,13 +22,13 @@ int main(int argc, char* argv[])
   //   servo_ids.push_back(i);
   //   positions.push_back(2048);
   //   speeds.push_back(1023);
-  
+
   //   unsigned int max_torque = 0;
   //   hans_robot.getMaxTorque(i,max_torque);
   //   std::cout << max_torque << std::endl;
 
   //   hans_robot.setTorqueEnable(i, true);
-    
+
   //   unsigned int position = 0;
   //   hans_robot.getPosition(i, position);
   //   hans_robot.setPosition(i, position);

--- a/hans_cute_driver/src/serial_command.cpp
+++ b/hans_cute_driver/src/serial_command.cpp
@@ -1,7 +1,7 @@
 #include "hans_cute_driver/serial_command.h"
 
-SerialCommand::SerialCommand(const std::string port, const long baudrate)
-    : port_(port), baudrate_(baudrate), timeout_(30), num_tries_(5)
+SerialCommand::SerialCommand(const unsigned int &timeout, const unsigned int &num_tries)
+    : timeout_(timeout), num_tries_(num_tries)
 {
   // serial_port_ = std::make_shared<SerialPort>(port, baudrate, timeout_);
 
@@ -9,7 +9,7 @@ SerialCommand::SerialCommand(const std::string port, const long baudrate)
   //  signal(SIGTERM,SerialCommand::sigTermHandler);
 }
 
-SerialCommand::SerialCommand() : SerialCommand("/dev/ttyUSB0", 115200)
+SerialCommand::SerialCommand() : SerialCommand(30,5)
 {
 }
 

--- a/hans_cute_driver/src/serial_command.cpp
+++ b/hans_cute_driver/src/serial_command.cpp
@@ -15,7 +15,7 @@ SerialCommand::SerialCommand() : SerialCommand(30,5)
 
 SerialCommand::~SerialCommand()
 {
-  std::cout << "SerialCommand Destructor" << std::endl;
+  // std::cout << "SerialCommand Destructor" << std::endl;
   close();
 }
 

--- a/hans_cute_driver/test/test_hans_cute_driver.cpp
+++ b/hans_cute_driver/test/test_hans_cute_driver.cpp
@@ -16,7 +16,8 @@ protected:
     hans_robot_.setSerialPort(serial_port_);
     hans_robot_.open();
 
-    ping_return_data_ = {0xFF, 0xFF, 0x01, 0x02, 0x00, 0xFC};
+    correct_status_packet_ = {0xFF, 0xFF, 0x01, 0x02, 0x00, 0xFC};
+    corrupted_status_packet_ = {0xFA, 0xFB, 0x00};
   };
 
   virtual void TearDown() override{
@@ -27,24 +28,79 @@ protected:
   std::shared_ptr<SerialPortInterface> serial_port_;
   HansCuteRobot::ServoDriver hans_robot_;
 
-  std::vector<uint8_t> ping_return_data_;
+  std::vector<uint8_t> correct_status_packet_;
+  std::vector<uint8_t> corrupted_status_packet_;
 };
 
 TEST_F(ServoDriverTest, test_calcChecksum)
 {
-  ASSERT_EQ(ping_return_data_.back(), hans_robot_.calcCheckSum(ping_return_data_));
+  ASSERT_EQ(correct_status_packet_.back(), hans_robot_.calcCheckSum(correct_status_packet_));
+}
+
+TEST_F(ServoDriverTest, test_readResponseCorrectStatusPacket)
+{
+  serial_port_->setReadDataStream(correct_status_packet_);
+  std::vector<uint8_t> response;
+  bool status = hans_robot_.readResponse(response);
+  ASSERT_TRUE(status);
+  ASSERT_EQ(response, correct_status_packet_);
+}
+
+// TODO: Maybe it's better to move ground truth into individual tests
+TEST_F(ServoDriverTest, test_readResponseCorruptedStatusPacket)
+{
+  serial_port_->setReadDataStream(corrupted_status_packet_);
+  std::vector<uint8_t> response;
+  bool status = hans_robot_.readResponse(response);
+  ASSERT_FALSE(status);
+}
+
+TEST_F(ServoDriverTest, test_read)
+{
+  uint8_t id = 0x01;
+  uint8_t address = 0x2B;
+  uint8_t length = 0x01;
+  std::vector<uint8_t> ground_truth_read_io_stream = {0xFF, 0xFF, 0x01, 0x04, 0x02, 0x2B, 0x01, 0xCC};
+  std::vector<uint8_t> read_io_stream;
+  
+  std::vector<uint8_t> ground_truth_read_return_stream = {0xFF, 0xFF,0x01,0x03,0x00,0x20,0xDB};
+  std::vector<uint8_t> read_return_stream;
+
+  unsigned long timestamp;
+
+  serial_port_->setReadDataStream(ground_truth_read_return_stream);
+  bool status = hans_robot_.read(id, address, length, read_return_stream, timestamp);
+  serial_port_->getWriteDataStream(read_io_stream);
+
+  ASSERT_TRUE(status);
+  ASSERT_EQ(read_io_stream, ground_truth_read_io_stream);
 }
 
 TEST_F(ServoDriverTest, test_write)
 {
+  uint8_t id = 0x01;
+  uint8_t address = 0x03;
   std::vector<uint8_t> ground_truth_write = {0xFF, 0xFF, 0x01, 0x04, 0x03, 0x03, 0x00, 0xF4};
   std::vector<uint8_t> raw_data = {0x00};
-  std::vector<uint8_t> write_data;
+  std::vector<uint8_t> write_io_stream;
+  std::vector<uint8_t> write_return_stream;
   unsigned long timestamp;
 
-  hans_robot_.write(0x01, 0x03, raw_data, timestamp);
-  serial_port_->getWriteDataStream(write_data);
-  EXPECT_EQ(write_data, ground_truth_write);
+  hans_robot_.write(id, address, raw_data, write_return_stream, timestamp);
+  serial_port_->getWriteDataStream(write_io_stream);
+  ASSERT_EQ(write_io_stream, ground_truth_write);
+}
+
+TEST_F(ServoDriverTest, test_ping)
+{
+  uint8_t id = 0x01;
+  std::vector<uint8_t> ground_truth_ping = {0xFF, 0xFF, 0x01, 0x02, 0x01, 0xFB};
+  std::vector<uint8_t> ping_io_stream;
+  std::vector<uint8_t> ping_return_stream;
+
+  hans_robot_.ping(id,ping_return_stream);
+  serial_port_->getWriteDataStream(ping_io_stream);
+  ASSERT_EQ(ping_io_stream, ground_truth_ping);
 }
 
 int main(int argc, char **argv)

--- a/hans_cute_driver/test/test_hans_cute_driver.cpp
+++ b/hans_cute_driver/test/test_hans_cute_driver.cpp
@@ -1,0 +1,54 @@
+#include "gtest/gtest.h"
+
+#include "hans_cute_driver/hans_cute_driver.h"
+#include "hans_cute_driver/hans_cute_const.h"
+#include "custom_serial_port/dummy_serial_port.h"
+
+class ServoDriverTest : public ::testing::Test
+{
+protected:
+  virtual void SetUp() override
+  {
+    std::string port = "/dev/ttyUSB0";
+    unsigned int baud_rate = 250000;
+
+    serial_port_ = std::make_shared<DummySerialPort>(port, baud_rate);
+    hans_robot_.setSerialPort(serial_port_);
+    hans_robot_.open();
+
+    ping_return_data_ = {0xFF, 0xFF, 0x01, 0x02, 0x00, 0xFC};
+  };
+
+  virtual void TearDown() override{
+
+  };
+
+protected:
+  std::shared_ptr<SerialPortInterface> serial_port_;
+  HansCuteRobot::ServoDriver hans_robot_;
+
+  std::vector<uint8_t> ping_return_data_;
+};
+
+TEST_F(ServoDriverTest, test_calcChecksum)
+{
+  ASSERT_EQ(ping_return_data_.back(), hans_robot_.calcCheckSum(ping_return_data_));
+}
+
+TEST_F(ServoDriverTest, test_write)
+{
+  std::vector<uint8_t> ground_truth_write = {0xFF, 0xFF, 0x01, 0x04, 0x03, 0x03, 0x00, 0xF4};
+  std::vector<uint8_t> raw_data = {0x00};
+  std::vector<uint8_t> write_data;
+  unsigned long timestamp;
+
+  hans_robot_.write(0x01, 0x03, raw_data, timestamp);
+  serial_port_->getWriteDataStream(write_data);
+  EXPECT_EQ(write_data, ground_truth_write);
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/hans_cute_status_manager/src/hans_cute_status_manager.cpp
+++ b/hans_cute_status_manager/src/hans_cute_status_manager.cpp
@@ -37,9 +37,9 @@ void HansCuteStatusManager::updateJointParams(const std::vector<ServoParams> &se
     servos_params_.at(id).acceleration = servo_params.at(id).acceleration;
 
     // Update hardware with new values
-    servo_driver_ptr_->setAngleLimits(id,servos_params_.at(id).raw_min,servos_params_.at(id).raw_max);
-    servo_driver_ptr_->setSpeed(id,servos_params_.at(id).speed);
-    servo_driver_ptr_->setAcceleration(id,servos_params_.at(id).acceleration);
+    servo_driver_ptr_->setAngleLimits(id, servos_params_.at(id).raw_min, servos_params_.at(id).raw_max);
+    servo_driver_ptr_->setSpeed(id, servos_params_.at(id).speed);
+    servo_driver_ptr_->setAcceleration(id, servos_params_.at(id).acceleration);
   }
 }
 
@@ -60,7 +60,6 @@ bool HansCuteStatusManager::initialise()
 
 bool HansCuteStatusManager::start()
 {
-
 }
 
 bool HansCuteStatusManager::stop()
@@ -91,8 +90,7 @@ bool HansCuteStatusManager::findServos()
 
       // We should wrap this ping function in driver maybe
       std::vector<uint8_t> response;
-      servo_driver_ptr_->ping((uint8_t)servo_id);
-      servo_driver_ptr_->readResponse(response);
+      servo_driver_ptr_->ping((uint8_t)servo_id, response);
       if (response.size() == 0)
       {
         continue;

--- a/hans_cute_status_manager/src/hans_cute_status_manager.cpp
+++ b/hans_cute_status_manager/src/hans_cute_status_manager.cpp
@@ -91,7 +91,8 @@ bool HansCuteStatusManager::findServos()
 
       // We should wrap this ping function in driver maybe
       std::vector<uint8_t> response;
-      servo_driver_ptr_->ping((uint8_t)servo_id, response);
+      servo_driver_ptr_->ping((uint8_t)servo_id);
+      servo_driver_ptr_->readResponse(response);
       if (response.size() == 0)
       {
         continue;

--- a/hans_cute_status_manager/src/main.cpp
+++ b/hans_cute_status_manager/src/main.cpp
@@ -4,7 +4,7 @@
 int main()
 {
   std::shared_ptr<HansCuteRobot::ServoDriver> servo_driver_ptr =
-      std::make_shared<HansCuteRobot::ServoDriver>("/dev/ttyUSB0", 250000);
+      std::make_shared<HansCuteRobot::ServoDriver>();
   servo_driver_ptr->open();
   
   // Start status manager


### PR DESCRIPTION
## What

Testing is important when it comes to designing robust software. The current code base was not developed with testing in mind from the beginning. As such, it is important to refactor it slightly to support unit testing for now and system testing with ros in the future.

## How
- Moved custom_serial_port to be a separate library.
- Added an abstract serial port class to support testing with mock data write and read return data.
- Changed `SerialCommand` object to inject a `SerialPortInterface` interface instead of initialising an object to support testing.
- Added a basic unit test to test basic read write functionality of the hans protocol