### PR TITLE
Testing/test build process for 16 18 20

### DIFF
--- a/docker/Dockerfile.u16
+++ b/docker/Dockerfile.u16
@@ -1,0 +1,17 @@
+FROM ros:kinetic-robot
+
+RUN apt update && apt install -y g++ git autogen autoconf build-essential cmake
+
+RUN echo "source /opt/ros/kinetic/setup.bash" >> ~/.bashrc
+RUN bin/bash -c "source /opt/ros/kinetic/setup.bash && \
+                    mkdir -p /hans_ws/src && \
+                    cd /hans_ws/src && \
+                    catkin_init_workspace && \
+                    cd /hans_ws/ && \
+                    catkin_make && \
+                    cd src/ && \
+                    git clone -b testing/test-build-process-for-16-18-20 https://github.com/dkhoanguyen/hans-cute-driver && \
+                    cd /hans_ws/ && \
+                    catkin_make"
+
+CMD [ "bash", "-c", "tail -f /dev/null" ] 

--- a/docker/Dockerfile.u18
+++ b/docker/Dockerfile.u18
@@ -1,0 +1,17 @@
+FROM ros:melodic-robot
+
+RUN apt update && apt install -y g++ git autogen autoconf build-essential cmake
+
+RUN echo "source /opt/ros/melodic/setup.bash" >> ~/.bashrc
+RUN bin/bash -c "source /opt/ros/melodic/setup.bash && \
+                    mkdir -p /hans_ws/src && \
+                    cd /hans_ws/src && \
+                    catkin_init_workspace && \
+                    cd /hans_ws/ && \
+                    catkin_make && \
+                    cd src/ && \
+                    git clone -b testing/test-build-process-for-16-18-20 https://github.com/dkhoanguyen/hans-cute-driver && \
+                    cd /hans_ws/ && \
+                    catkin_make"
+
+CMD [ "bash", "-c", "tail -f /dev/null" ] 

--- a/docker/Dockerfile.u20
+++ b/docker/Dockerfile.u20
@@ -1,0 +1,17 @@
+FROM ros:noetic-robot
+
+RUN apt update && apt install -y g++ git autogen autoconf build-essential cmake
+
+RUN echo "source /opt/ros/noetic/setup.bash" >> ~/.bashrc
+RUN bin/bash -c "source /opt/ros/noetic/setup.bash && \
+                    mkdir -p /hans_ws/src && \
+                    cd /hans_ws/src && \
+                    catkin_init_workspace && \
+                    cd /hans_ws/ && \
+                    catkin_make && \
+                    cd src/ && \
+                    git clone -b testing/test-build-process-for-16-18-20 https://github.com/dkhoanguyen/hans-cute-driver && \
+                    cd /hans_ws/ && \
+                    catkin_make"
+
+CMD [ "bash", "-c", "tail -f /dev/null" ] 

--- a/hans_cute_controllers/CMakeLists.txt
+++ b/hans_cute_controllers/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0.2)
 project(hans_cute_controllers)
 
 # # Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+add_compile_options(-std=c++11)
 
 # # Find catkin macros and libraries
 # # if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/hans_cute_controllers/nodes/include/controller_manager.h
+++ b/hans_cute_controllers/nodes/include/controller_manager.h
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <deque>
 #include <thread>
+#include <memory>
 
 #include <ros/ros.h>
 #include "trajectory_msgs/JointTrajectory.h"

--- a/hans_cute_controllers/nodes/src/controller_manager.cpp
+++ b/hans_cute_controllers/nodes/src/controller_manager.cpp
@@ -126,7 +126,7 @@ void HansCuteControllerManager::initialise()
 
 void HansCuteControllerManager::start()
 {
-  control_thread_ = std::make_unique<std::thread>(std::thread(&HansCuteControllerManager::controlThread, this));
+  control_thread_ = std::unique_ptr<std::thread>(new std::thread(&HansCuteControllerManager::controlThread, this));
 }
 
 void HansCuteControllerManager::stop()

--- a/hans_cute_driver/CMakeLists.txt
+++ b/hans_cute_driver/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0.2)
 project(hans_cute_driver)
 
 # # Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++17)
+add_compile_options(-std=c++11)
 
 # # Find catkin macros and libraries
 # # if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/hans_cute_driver/test/test_hans_cute_driver.cpp
+++ b/hans_cute_driver/test/test_hans_cute_driver.cpp
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-
+#include <memory>
 #include "hans_cute_driver/hans_cute_driver.h"
 #include "hans_cute_driver/hans_cute_const.h"
 #include "custom_serial_port/dummy_serial_port.h"

--- a/hans_cute_status_manager/CMakeLists.txt
+++ b/hans_cute_status_manager/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0.2)
 project(hans_cute_status_manager)
 
 # # Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+add_compile_options(-std=c++11)
 
 # # Find catkin macros and libraries
 # # if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)


### PR DESCRIPTION
## What

We need to add support for ubuntu and ros versions that are older than the 20.04, namely 18.04 with ros melodic and 16.04 with ros kinetic.

## How
- Changed to compiler to use c++11 instead of 14 or 17
- Used docker to ensure the build process of 16 and 18 finish cleanly